### PR TITLE
refactor(Neutral): each module are exposed by Neutral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "neutral"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "assert_approx_eq",
  "futures",
@@ -514,6 +514,7 @@ dependencies = [
  "hyper-tls",
  "lazy_static",
  "mockito",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_with",
@@ -738,6 +739,15 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -1086,3 +1096,9 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neutral"
 authors = ["Maximilien DI DIO <mdidio@pm.me>"]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Unofficial rust client for neutrinoapi.com"
 keywords = ["neutrinoapi", "client", "api"]
@@ -20,6 +20,7 @@ mockito = "0.30.0"
 futures = "0.3.17"
 assert_approx_eq = "1.1.0"
 serde_with = "1.14.0"
+secrecy = "0.8.0"
 
 [dependencies.tokio]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 Provide an API to interact with some features provided by [neutrinoapi.com](https://www.neutrinoapi.com).
 
 # What is neutrinoapi.com
-A general-purpose tool that solves recurring problems encountered during the development of software systems. It is used across many industries by software developers, data scientists and systems operators. 
+A general-purpose tool that solves recurring problems encountered during the development of software systems. It is used across many industries by software developers, data scientists and systems operators.
+
+# How to use the neutral crate ?
+The [Neutral](./struct.Neutral.html) structure act as an API client of neutrinoapi.
+Features are represented by modules, each module contains a struct which implement a `send` method to call neutrinoapi.com. Use an instance of [Neutral](./struct.Neutral.html) to interact with neutrinoapi.
 
 
-# How to use the neutral crate ? 
-The API is describe the the [Neutral](https://docs.rs/neutral/latest/neutral/struct.Neutral.html) structure. 
-Features are represented by module, each module contains a `send` function which call neutrinoapi.com using an instance of [Neutral](https://docs.rs/neutral/latest/neutral/struct.Neutral.html) structure.
-
-By example, ip info feature from neutrinoapi is implemented inside the [neutral::ip_info](https://docs.rs/neutral/latest/neutral/ip_info/index.html) module.
+Example for ip_info endpoint:
 
 ```rust
-let api_auth = ApiAuth::new("userid", "apikey");
-let client = Neutral::try_new("https://neutrinoapi.net", api_auth).unwrap();
-let ip_info_response = ip_info::send(&client, ip_addr).await.unwrap();
+let api_auth = ApiAuth::new("userid".to_string(), "apikey".to_string());
+let neutral = Neutral::try_new("https://neutrinoapi.net", api_auth).unwrap();
+let ip_info_response = neutral.ip_info().send(ip_addr).await.unwrap();
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,17 @@
+//! # Contains error types
+//! Contains all different type of errors that could possibly happen.
+
 use http::StatusCode;
 use tokio::time::error::Elapsed;
 
+/// Represent a generic error from neutrinoapi.com.
 #[derive(Debug)]
 pub struct NeutrinoError {
     pub status_code: StatusCode,
     pub error: String,
 }
 
+/// Represent the to level error of the neutral crate.
 #[derive(Debug)]
 pub enum Error {
     Hyper(hyper::Error),

--- a/src/ip_probe.rs
+++ b/src/ip_probe.rs
@@ -4,15 +4,12 @@
 //!
 //! This API will run a series of live network scans and service probes to extract useful details about the host provider.
 
-use http::{Method, StatusCode};
+use http::Method;
 use hyper::Body;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
-use crate::{
-    error::{Error, NeutrinoError},
-    Neutral, NeutrinoProviderKind,
-};
+use crate::{error::Error, Neutral, NeutrinoProviderKind};
 
 #[cfg(test)]
 use mockito;
@@ -53,31 +50,23 @@ pub struct IpProbeResponse {
     pub is_v6: bool,
 }
 
-/// Send an ip probe request to neutrinoapi.com
-pub async fn send(neutral: &Neutral<'_>, ip_addr: IpAddr) -> Result<IpProbeResponse, Error> {
-    let path_and_query = format!("/ip-probe?output-case=snake&ip={}", ip_addr.to_string());
-    let request = neutral
-        .request_builder(path_and_query)?
-        .method(Method::GET)
-        .body(Body::empty())?;
+pub struct IpProbe<'a> {
+    pub(crate) neutral: &'a Neutral,
+}
 
-    let client = &neutral.client;
-    let request = neutral.add_authentication_headers(request);
+impl<'a> IpProbe<'a> {
+    /// Send an ip probe request to neutrinoapi.com
+    pub async fn send(&self, ip_addr: IpAddr) -> Result<IpProbeResponse, Error> {
+        let path_and_query = format!("/ip-probe?output-case=snake&ip={}", ip_addr.to_string());
+        let request = self
+            .neutral
+            .request_builder(path_and_query)?
+            .method(Method::GET)
+            .body(Body::empty())?;
 
-    let http_resp = client.request(request).await?;
-
-    match http_resp.status() {
-        StatusCode::OK => {
-            let body = hyper::body::to_bytes(http_resp.into_body()).await?;
-            let response: IpProbeResponse = serde_json::from_slice(&body)?;
-            Ok(response)
-        }
-        _ => {
-            let status_code = http_resp.status();
-            let body = hyper::body::to_bytes(http_resp.into_body()).await?;
-            let error = String::from_utf8_lossy(&body).into_owned();
-            Err(Error::Neutrino(NeutrinoError { status_code, error }))
-        }
+        let body = self.neutral.request(request).await?;
+        let response: IpProbeResponse = serde_json::from_slice(&body)?;
+        Ok(response)
     }
 }
 
@@ -184,12 +173,15 @@ mod test {
             expected: &expected_response,
         }];
 
-        let neutral =
-            Neutral::try_new(&mockito::server_url(), ApiAuth::new("User", "test")).unwrap();
+        let neutral = Neutral::try_new(
+            &mockito::server_url(),
+            ApiAuth::new("User".to_string(), "test".to_string()),
+        )
+        .unwrap();
 
         for test in &tests {
             let Args { ip_addr } = test.args;
-            let ip_probe_res = send(&neutral, ip_addr).await;
+            let ip_probe_res = neutral.ip_probe().send(ip_addr).await;
             let ip_probe_result = ip_probe_res.map(|ip_probe| ip_probe.clone());
             let expected = test.expected;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,25 +5,32 @@
 //! A general-purpose tool that solves recurring problems encountered during the development of software systems. It is used across many industries by software developers, data scientists and systems operators.
 
 //! # How to use the neutral crate ?
-//! The API is describe the the [Neutral](./struct.Neutral.html) structure.
-//! Features are represented by module, each module contains a `send` function which call neutrinoapi.com using an instance of [Neutral](./struct.Neutral.html) structure.
+//! The [Neutral](./struct.Neutral.html) structure act as an API client of neutrinoapi.
+//! Features are represented by modules, each module contains a struct which implement a `send` method to call neutrinoapi.com. Use an instance of [Neutral](./struct.Neutral.html) to interact with neutrinoapi.
 //!
 //!
-//! By example, ip info feature from neutrinoapi is implemented inside the [neutral:ip_info](./ip_info/index.html) module.
+//! Example for ip_info endpoint:
 //!
 //! ```ignore
-//! let api_auth = ApiAuth::new("userid", "apikey");
-//! let client = Neutral::try_new("https://neutrinoapi.net", api_auth).unwrap();
-//! let ip_info_response = ip_info::send(&client, ip_addr).await.unwrap();
+//! let api_auth = ApiAuth::new("userid".to_string(), "apikey".to_string());
+//! let neutral = Neutral::try_new("https://neutrinoapi.net", api_auth).unwrap();
+//! let ip_info_response = neutral.ip_info().send(ip_addr).await.unwrap();
 //! ```
 
+use error::NeutrinoError;
+use hlr_lookup::HlrLookup;
 use http::{
     uri::{Authority, Scheme},
-    Uri,
+    StatusCode, Uri,
 };
 
-use hyper::{client::HttpConnector, header::HeaderValue, Client, Request};
+use hyper::{body::Bytes, client::HttpConnector, Body, Client, Request};
 use hyper_tls::HttpsConnector;
+use ip_blocklist::IpBlocklist;
+use ip_info::IpInfo;
+use ip_probe::IpProbe;
+use phone_validate::PhoneValidate;
+use secrecy::{ExposeSecret, Secret};
 use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod error;
@@ -107,35 +114,34 @@ where
 }
 
 /// Provide authorization credentials for neutrinoapi.com
-#[derive(Debug, Serialize, Clone)]
-#[serde(rename_all(serialize = "kebab-case"))]
-pub struct ApiAuth<'a> {
-    user_id: &'a str,
-    api_key: &'a str,
+#[derive(Debug, Clone)]
+pub struct ApiAuth {
+    user_id: Secret<String>,
+    api_key: Secret<String>,
 }
 
-impl<'a> ApiAuth<'a> {
+impl ApiAuth {
     /// Create a new instance of `ApiAuth` using your neutrinoapi.com credentials.
-    pub fn new(user_id: &'a str, api_key: &'a str) -> Self {
+    pub fn new(user_id: String, api_key: String) -> Self {
         ApiAuth {
-            user_id: user_id,
-            api_key: api_key,
+            user_id: Secret::new(user_id),
+            api_key: Secret::new(api_key),
         }
     }
 }
 
 /// A client to consume features provided by neutrinoapi.com
 #[derive(Debug, Clone)]
-pub struct Neutral<'a> {
+pub struct Neutral {
     pub(crate) uri: Uri,
-    pub(crate) auth: ApiAuth<'a>,
+    pub(crate) auth: ApiAuth,
     pub(crate) client: Client<HttpsConnector<HttpConnector>>,
 }
 
-impl<'a> Neutral<'a> {
+impl<'a> Neutral {
     /// Create a new Neutral instance. Needs some credentials to be authorized.
     /// Provide your neutrinoapi.com userid and apikey with an instance of `ApiAuth` as argument.
-    pub fn try_new(uri: &str, auth: ApiAuth<'a>) -> Result<Self, Error> {
+    pub fn try_new(uri: &str, auth: ApiAuth) -> Result<Self, Error> {
         let mut https = HttpsConnector::new();
 
         #[cfg(test)]
@@ -144,7 +150,6 @@ impl<'a> Neutral<'a> {
         let uri = uri.parse::<Uri>()?;
 
         https.https_only(uri.scheme() == Some(&Scheme::HTTPS));
-
         Ok(Self {
             uri: uri,
             auth: auth,
@@ -168,25 +173,56 @@ impl<'a> Neutral<'a> {
             .scheme(self.scheme().unwrap().as_str())
     }
 
-    pub(crate) fn add_authentication_headers<B>(&self, request: Request<B>) -> Request<B> {
-        let user_id = self.auth.user_id;
-        let api_key = self.auth.api_key;
-        let mut request = Request::from(request);
-        request
-            .headers_mut()
-            .insert("user-id", HeaderValue::from_str(user_id).unwrap());
-        request
-            .headers_mut()
-            .insert("api-key", HeaderValue::from_str(api_key).unwrap());
-        request
-    }
-
     pub(crate) fn request_builder(
         &self,
         path_and_query: String,
     ) -> Result<http::request::Builder, Error> {
         let uri = self.uri_builder().path_and_query(path_and_query).build()?;
+        let request_builder = Request::builder()
+            .uri(uri)
+            .header("user-id", self.auth.user_id.expose_secret())
+            .header("api-key", self.auth.api_key.expose_secret());
+        Ok(request_builder)
+    }
 
-        Ok(Request::builder().uri(uri))
+    pub(crate) async fn request(&self, req: Request<Body>) -> Result<Bytes, Error> {
+        let http_resp = self.client.request(req).await?;
+        match http_resp.status() {
+            StatusCode::OK => {
+                let body = hyper::body::to_bytes(http_resp.into_body()).await?;
+                Ok(body)
+            }
+            _ => {
+                let status_code = http_resp.status();
+                let body = hyper::body::to_bytes(http_resp.into_body()).await?;
+                let error = String::from_utf8_lossy(&body).into_owned();
+                Err(Error::Neutrino(NeutrinoError { status_code, error }))
+            }
+        }
+    }
+
+    /// Returns an instance of PhoneValidate
+    pub fn phone_validate(&'a self) -> PhoneValidate<'a> {
+        PhoneValidate { neutral: self }
+    }
+
+    /// Returns an instance of IpInfo
+    pub fn ip_info(&'a self) -> IpInfo<'a> {
+        IpInfo { neutral: self }
+    }
+
+    /// Returns an instance of IpBlocklist
+    pub fn ip_blocklist(&'a self) -> IpBlocklist<'a> {
+        IpBlocklist { neutral: self }
+    }
+
+    /// Returns an instance of IpProbe
+    pub fn ip_probe(&'a self) -> IpProbe<'a> {
+        IpProbe { neutral: self }
+    }
+
+    /// Returns an instance of HlrLookup
+    pub fn hlr_lookup(&'a self) -> HlrLookup<'a> {
+        HlrLookup { neutral: self }
     }
 }


### PR DESCRIPTION
The API is simplify in order to let the developer call a neutrino endpoint directly using an instance of Neutral. Also each send method implemented was refactorized in order to avoid some repetitions. (to be more DRY)

BREAKING CHANGES: of course, this version brake the previous versions