### PR TITLE
Move all neutrinoapi.com related types into the neutral_types crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,11 +514,23 @@ dependencies = [
  "hyper-tls",
  "lazy_static",
  "mockito",
+ "neutral_types",
  "secrecy",
  "serde",
  "serde_json",
  "serde_with",
  "tokio",
+]
+
+[[package]]
+name = "neutral_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a47eedd42bdca913e85b5329de53a5a29ada324d98cadb6c0f3091a2eb971a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.17"
 assert_approx_eq = "1.1.0"
 serde_with = "1.14.0"
 secrecy = "0.8.0"
+neutral_types = "0.1.0"
 
 [dependencies.tokio]
 version = "1"

--- a/src/hlr_lookup.rs
+++ b/src/hlr_lookup.rs
@@ -5,60 +5,15 @@
 //!
 //! The home location register (HLR) is a central database that contains details of each mobile phone subscriber connected to the global mobile network. You can use this API to validate that a mobile number is live and registered on a mobile network in real-time. Find out the carrier name, ported number status and fetch up-to-date device status information.
 
-use crate::{Neutral, PhoneInfoKind};
+use crate::Neutral;
 use http::Method;
 use hyper::Body;
-use serde::{Deserialize, Serialize};
+use neutral_types::hlr_lookup::HlrLookupResponse;
 
 use crate::error::Error;
 
 #[cfg(test)]
 use mockito;
-
-/// Describes Hlr Status from Hrl lookup API
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case", serialize = "kebab-case"))]
-pub enum HlrStatus {
-    Ok,
-    Absent,
-    Unknown,
-    Invalid,
-    FixedLine,
-    Voip,
-    Failed,
-}
-
-/// Response of hlr lookup neutrinoapi.com endpoint
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct HlrLookupResponse {
-    #[serde(rename(deserialize = "number_valid"))]
-    pub is_valid: bool,
-    #[serde(rename(deserialize = "hlr_valid"))]
-    pub is_hlr_valid: bool,
-    pub hlr_status: HlrStatus,
-    pub is_mobile: bool,
-    pub is_ported: bool,
-    pub is_roaming: bool,
-    pub imsi: String,
-    pub mcc: String,
-    pub mnc: String,
-    pub msin: String,
-    pub msc: String,
-    pub current_network: String,
-    pub origin_network: String,
-    pub ported_network: String,
-    #[serde(rename(deserialize = "number_type"))]
-    pub kind: PhoneInfoKind,
-    pub location: String,
-    pub country: String,
-    pub country_code: String,
-    pub country_code3: String,
-    pub currency_code: String,
-    pub roaming_country_code: String,
-    pub international_calling_code: String,
-    pub international_number: String,
-    pub local_number: String,
-}
 
 pub struct HlrLookup<'a> {
     pub(crate) neutral: &'a Neutral,
@@ -89,6 +44,7 @@ mod test {
     use super::*;
     use crate::ApiAuth;
     use mockito::{mock, Matcher};
+    use neutral_types::{hlr_lookup::HlrStatus, PhoneInfoKind};
 
     #[tokio::test]
     async fn test_hlr_lookup_with_good_phone_number() {

--- a/src/ip_blocklist.rs
+++ b/src/ip_blocklist.rs
@@ -23,38 +23,16 @@
 //! * Exploit scanners
 //! * Brute-force crackers
 
-use crate::{Neutral, NeutrinoSensor};
+use crate::Neutral;
 use http::Method;
 use hyper::Body;
-use serde::{Deserialize, Serialize};
+use neutral_types::ip_blocklist::IpBlocklistResponse;
 use std::net::IpAddr;
 
 use crate::error::Error;
 
 #[cfg(test)]
 use mockito;
-
-/// Response of ip blocklist neutrinoapi.com endpoint
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct IpBlocklistResponse {
-    pub ip: IpAddr,
-    pub is_listed: bool,
-    pub last_seen: usize,
-    pub list_count: usize,
-    pub blocklists: Vec<String>,
-    pub sensors: Vec<NeutrinoSensor>,
-    pub is_proxy: bool,
-    pub is_tor: bool,
-    pub is_vpn: bool,
-    pub is_malware: bool,
-    pub is_spyware: bool,
-    pub is_dshield: bool,
-    pub is_hijacked: bool,
-    pub is_spider: bool,
-    pub is_bot: bool,
-    pub is_spam_bot: bool,
-    pub is_exploit_bot: bool,
-}
 
 pub struct IpBlocklist<'a> {
     pub(crate) neutral: &'a Neutral,

--- a/src/ip_info.rs
+++ b/src/ip_info.rs
@@ -16,40 +16,16 @@
 //! * Traffic analysis
 //! * Access controls
 
-use crate::{object_empty_as_none, Neutral, NeutrinoTimeZoneResponse};
+use crate::Neutral;
 use http::Method;
 use hyper::Body;
-use serde::{Deserialize, Serialize};
+use neutral_types::ip_info::IpInfoResponse;
 use std::net::IpAddr;
 
 use crate::error::Error;
 
 #[cfg(test)]
 use mockito;
-
-/// Response of ip info neutrinoapi.com endpoint
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct IpInfoResponse {
-    pub ip: IpAddr,
-    #[serde(alias = "valid", alias = "is_valid")]
-    pub is_valid: bool,
-    pub is_v6: bool,
-    pub is_v4_mapped: bool,
-    pub is_bogon: bool,
-    pub country: String,
-    pub country_code: String,
-    pub country_code3: String,
-    pub continent_code: String,
-    pub currency_code: String,
-    pub city: String,
-    pub region: String,
-    pub longitude: f64,
-    pub latitude: f64,
-    pub hostname: String,
-    pub host_domain: String,
-    #[serde(deserialize_with = "object_empty_as_none")]
-    pub timezone: Option<NeutrinoTimeZoneResponse>,
-}
 
 pub struct IpInfo<'a> {
     pub(crate) neutral: &'a Neutral,
@@ -76,6 +52,7 @@ mod test {
     use super::*;
     use crate::ApiAuth;
     use mockito::{mock, Matcher};
+    use neutral_types::NeutrinoTimeZoneResponse;
     use std::net::{IpAddr, Ipv4Addr};
 
     #[tokio::test]

--- a/src/ip_probe.rs
+++ b/src/ip_probe.rs
@@ -6,49 +6,13 @@
 
 use http::Method;
 use hyper::Body;
-use serde::{Deserialize, Serialize};
+use neutral_types::ip_probe::IpProbeResponse;
 use std::net::IpAddr;
 
-use crate::{error::Error, Neutral, NeutrinoProviderKind};
+use crate::{error::Error, Neutral};
 
 #[cfg(test)]
 use mockito;
-
-/// Response of ip probe neutrinoapi.com endpoint
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct IpProbeResponse {
-    pub country: String,
-    pub country_code: String,
-    pub provider_domain: String,
-    pub city: String,
-    pub vpn_domain: String,
-    pub is_vpn: bool,
-    pub as_cidr: String,
-    #[serde(alias = "valid", alias = "is_valid")]
-    pub is_valid: bool,
-    pub provider_type: NeutrinoProviderKind,
-    pub hostname: String,
-    pub as_age: i64,
-    pub continent_code: String,
-    pub is_bogon: bool,
-    pub ip: IpAddr,
-    pub as_country_code: String,
-    pub provider_description: String,
-    pub as_country_code3: String,
-    pub is_v4_mapped: bool,
-    pub is_isp: bool,
-    pub provider_website: String,
-    pub as_description: String,
-    pub is_hosting: bool,
-    pub as_domains: Vec<String>,
-    pub host_domain: String,
-    pub is_proxy: bool,
-    pub currency_code: String,
-    pub region: String,
-    pub asn: String,
-    pub country_code3: String,
-    pub is_v6: bool,
-}
 
 pub struct IpProbe<'a> {
     pub(crate) neutral: &'a Neutral,
@@ -75,6 +39,7 @@ mod test {
     use super::*;
     use crate::ApiAuth;
     use mockito::{mock, Matcher};
+    use neutral_types::NeutrinoProviderKind;
     use std::net::{IpAddr, Ipv4Addr};
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ use ip_info::IpInfo;
 use ip_probe::IpProbe;
 use phone_validate::PhoneValidate;
 use secrecy::{ExposeSecret, Secret};
-use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod error;
 pub mod hlr_lookup;
@@ -44,74 +43,6 @@ use crate::error::Error;
 
 #[cfg(test)]
 use mockito;
-
-/// Describes a kind of phone number.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
-#[serde(rename_all(deserialize = "kebab-case", serialize = "kebab-case"))]
-pub enum PhoneInfoKind {
-    Mobile,
-    FixedLine,
-    PremiumRate,
-    TollFree,
-    Voip,
-    Unknown,
-}
-
-/// Describes a timezone from neutrinoapi.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct NeutrinoTimeZoneResponse {
-    pub id: String,
-    pub name: String,
-    pub abbr: String,
-    pub date: String,
-    pub time: String,
-    pub offset: String,
-}
-
-/// Describes a network provider.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(rename_all(deserialize = "snake_case", serialize = "snake_case"))]
-pub enum NeutrinoProviderKind {
-    Isp,
-    Hosting,
-    Vpn,
-    Proxy,
-    University,
-    Government,
-    Commercial,
-    Unknown,
-}
-
-/// Desribe a neutrinoapi sensor.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct NeutrinoSensor {
-    pub id: usize,
-    pub blocklist: String,
-    pub description: String,
-}
-
-pub(crate) fn object_empty_as_none<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
-where
-    D: Deserializer<'de>,
-    for<'a> T: Deserialize<'a>,
-{
-    #[derive(Deserialize, Debug)]
-    #[serde(deny_unknown_fields)]
-    struct Empty {}
-
-    #[derive(Deserialize, Debug)]
-    #[serde(untagged)]
-    enum Aux<T> {
-        T(T),
-        Empty(Empty),
-        Null,
-    }
-
-    match Deserialize::deserialize(deserializer)? {
-        Aux::T(t) => Ok(Some(t)),
-        Aux::Empty(_) | Aux::Null => Ok(None),
-    }
-}
 
 /// Provide authorization credentials for neutrinoapi.com
 #[derive(Debug, Clone)]

--- a/src/phone_validate.rs
+++ b/src/phone_validate.rs
@@ -7,31 +7,12 @@
 
 use http::Method;
 use hyper::Body;
-use serde::{Deserialize, Serialize};
+use neutral_types::phone_validate::PhoneValidateResponse;
 
-use crate::{error::Error, Neutral, PhoneInfoKind};
+use crate::{error::Error, Neutral};
 
 #[cfg(test)]
 use mockito;
-
-/// Response of phone validate neutrinoapi.com endpoint
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct PhoneValidateResponse {
-    #[serde(alias = "valid", alias = "is_valid")]
-    pub is_valid: bool,
-    #[serde(alias = "type", alias = "kind")]
-    pub kind: PhoneInfoKind,
-    pub international_calling_code: String,
-    pub international_number: String,
-    pub local_number: String,
-    pub location: String,
-    pub country: String,
-    pub country_code: String,
-    pub country_code3: String,
-    pub currency_code: String,
-    pub is_mobile: bool,
-    pub prefix_network: String,
-}
 
 pub struct PhoneValidate<'a> {
     pub(crate) neutral: &'a Neutral,
@@ -62,6 +43,7 @@ mod test {
     use super::*;
     use crate::ApiAuth;
     use mockito::{mock, Matcher};
+    use neutral_types::PhoneInfoKind;
 
     #[tokio::test]
     async fn test_phone_validate_with_good_phone_number() {


### PR DESCRIPTION
I decided to move all neutrinoapi.com related types from neutral to neutral_types. The goal is to share these types to many rust projects. It allows to implement another neutrinoapi.com client in rust by example.